### PR TITLE
bugfixes, speedrun/challenge/practice features

### DIFF
--- a/GameHandler.js
+++ b/GameHandler.js
@@ -77,7 +77,7 @@ export class GameHandler{
         
         this.projectiles = [];
         this.waveHandler = new WaveHandler(this);
-        this.waveHandler.fourthWaveEnraged();
+        this.waveHandler.firstWave();
         this.previousTime = performance.now();
         this.startTime = this.previousTime;
         this.totalTime = 0;

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -2,11 +2,49 @@ import {Ica} from './Ica.js';
 import { Etelhordo } from './etelhordo.js';
 import { Projectile } from './projectile.js';
 import { WaveHandler } from './waveHandler.js';
+import { Text } from './text.js';
 export class GameHandler{
+    #texts = [];
     constructor(ctx, width, height){
+        const urlParams = new URLSearchParams(window.location.search);
+
+        this.timerText = undefined;
+        if (urlParams.has("timer")) {
+            const paramTimer = !!+urlParams.get("timer");
+            if (paramTimer) {
+                this.timerText = new Text(ctx, this, "Time: {0}", 0);
+                this.#texts.push(this.timerText);
+            }
+        }
+
+        let icaHP = undefined;
+        this.maxHPText = undefined;
+        if (urlParams.has("icahp")) {
+            const paramHP = +urlParams.get("icahp");
+            // GameOver only runs on 'GotHit', so HP == 0 is no-hit mode.
+            if (Number.isSafeInteger(paramHP) && paramHP != Ica.defaultHP) {
+                icaHP = paramHP < 0 ? 0 : paramHP;
+            }
+        }
+        if (icaHP != undefined) {
+            this.maxHPText = new Text(ctx, this, "MHP: {0}", icaHP);
+            this.#texts.push(this.maxHPText);
+        }
+
+        this.timescale = 1;
+        this.speedText = undefined;
+        if (urlParams.has("speed")) {
+            const paramSpeed = Math.round((+urlParams.get("speed"))*100)/100;
+            if (Number.isFinite(paramSpeed) && paramSpeed != 1 && paramSpeed > 0) {
+                this.timescale = Math.round(paramSpeed*100)/100;
+                this.speedText = new Text(ctx, this, "Speed: {0}x", this.timescale);
+                this.#texts.push(this.speedText);
+            }
+        }
+
         this.ctx = ctx;
         this.enemies = [];
-        this.Ica = new Ica(ctx, 0, 0, 128, 128, this);
+        this.Ica = new Ica(ctx, 0, 0, 128, 128, this, icaHP);
         this.width = width;
         this.height = height;
         this.startGameLoop = this.startGameLoop.bind(this);
@@ -17,6 +55,8 @@ export class GameHandler{
         this.waveHandler = new WaveHandler(this);
         this.waveHandler.firstWave();
         this.previousTime = performance.now();
+        this.startTime = this.previousTime;
+        this.totalTime = 0;
         this.deltaTime = 0;
 
     }
@@ -40,14 +80,17 @@ export class GameHandler{
             
         }
         this.Ica.draw();
+        this.updateTimer();
+        this.drawTexts();
+
         requestAnimationFrame(this.startGameLoop);
         
     }
     calculateDeltaTime(){
         let currentTime = performance.now();
-        this.deltaTime =(currentTime - this.previousTime) / 1000;
+        this.deltaTime =(currentTime - this.previousTime) / 1000 * this.timescale;
         this.previousTime = currentTime;
-
+        this.totalTime = (currentTime-this.startTime)/1000;
     }
     drawHitboxes(){
         this.Ica.drawHitbox();
@@ -58,12 +101,24 @@ export class GameHandler{
             
         }
     }
+    updateTimer(){
+        if (this.timerText == undefined) {
+            return;
+        }
+        this.timerText.value = this.totalTime;
+    }
+    drawTexts(){
+        let currentY = 0;
+        for (let i = 0; i < this.#texts.length; i++) {
+            const element = this.#texts[i];
+            currentY += element.size;
+            element.draw(10, currentY)
+        }
+    }
     gameOver(){
         window.open("./gameover.html", "_self");
     }
     gameWin(){
         window.open("./win.html", "_self");
     }
-
-    
 }

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -8,7 +8,6 @@ export class GameHandler{
     #texts = [];
     constructor(ctx, width, height){
         const urlParams = new URLSearchParams(window.location.search);
-
         this.timerText = undefined;
         if (urlParams.has("timer")) {
             const paramTimer = !!+urlParams.get("timer");
@@ -141,9 +140,10 @@ export class GameHandler{
         }
     }
     gameOver(){
-        window.open("./gameover.html", "_self");
+        
+        window.open("./gameover.html" + window.location.search, "_self");
     }
     gameWin(){
-        window.open("./win.html", "_self");
+        window.open("./win.html" + window.location.search, "_self");
     }
 }

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -57,9 +57,7 @@ export class GameHandler{
         this.damageText = undefined;
         if (urlParams.has("damage")) {
             const paramDamage = Math.round((+urlParams.get("damage"))*100)/100;
-            console.log(paramDamage)
             if (Number.isFinite(paramDamage) && paramDamage != Kanal.damage && paramDamage > 0) {
-                console.log(paramDamage)
                 Kanal.damage = paramDamage;
                 this.damageText = new Text(ctx, this, "DMG: {0}", Kanal.damage);
                 this.#texts.push(this.damageText);

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -3,6 +3,7 @@ import { Etelhordo } from './etelhordo.js';
 import { Projectile } from './projectile.js';
 import { WaveHandler } from './waveHandler.js';
 import { Text } from './text.js';
+import { Kanal } from './kanal.js';
 export class GameHandler{
     #texts = [];
     constructor(ctx, width, height){
@@ -36,9 +37,22 @@ export class GameHandler{
         if (urlParams.has("speed")) {
             const paramSpeed = Math.round((+urlParams.get("speed"))*100)/100;
             if (Number.isFinite(paramSpeed) && paramSpeed != 1 && paramSpeed > 0) {
-                this.timescale = Math.round(paramSpeed*100)/100;
+                this.timescale = paramSpeed;
                 this.speedText = new Text(ctx, this, "Speed: {0}x", this.timescale);
                 this.#texts.push(this.speedText);
+            }
+        }
+
+        
+        this.damageText = undefined;
+        if (urlParams.has("damage")) {
+            const paramDamage = Math.round((+urlParams.get("damage"))*100)/100;
+            console.log(paramDamage)
+            if (Number.isFinite(paramDamage) && paramDamage != Kanal.damage && paramDamage > 0) {
+                console.log(paramDamage)
+                Kanal.damage = paramDamage;
+                this.damageText = new Text(ctx, this, "DMG: {0}", Kanal.damage);
+                this.#texts.push(this.damageText);
             }
         }
 

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -105,7 +105,7 @@ export class GameHandler{
         if (this.timerText == undefined) {
             return;
         }
-        this.timerText.value = this.totalTime;
+        this.timerText.value = Math.round(this.totalTime*1000)/1000;
     }
     drawTexts(){
         let currentY = 0;

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -35,11 +35,9 @@ export class GameHandler{
             // GameOver only runs on 'GotHit', so HP == 0 is no-hit mode.
             if (Number.isSafeInteger(paramHP) && paramHP != Ica.defaultHP) {
                 icaHP = paramHP < 0 ? 0 : paramHP;
+                this.maxHPText = new Text(ctx, this, "MHP: {0}", icaHP);
+                this.#texts.push(this.maxHPText);
             }
-        }
-        if (icaHP != undefined) {
-            this.maxHPText = new Text(ctx, this, "MHP: {0}", icaHP);
-            this.#texts.push(this.maxHPText);
         }
 
         this.timescale = 1;
@@ -63,6 +61,14 @@ export class GameHandler{
                 this.#texts.push(this.damageText);
             }
         }
+        
+        let startWave = 0;
+        if (urlParams.has("wave")) {
+            const paramWave = +urlParams.get("wave");
+            if (Number.isSafeInteger(paramWave)) {
+                startWave = paramWave;
+            }
+        }
 
         this.ctx = ctx;
         this.enemies = [];
@@ -75,7 +81,23 @@ export class GameHandler{
         
         this.projectiles = [];
         this.waveHandler = new WaveHandler(this);
-        this.waveHandler.firstWave();
+        switch (startWave) {
+            case 2:
+                this.waveHandler.secondWave();
+                break;
+            case 3:
+                this.waveHandler.thirdWave();
+                break;
+            case 4:
+                this.waveHandler.fourthWave();
+                break;
+            case 5:
+                this.waveHandler.fourthWaveEnraged();
+                break;
+            default:
+                this.waveHandler.firstWave()
+                break;
+        }
         this.previousTime = performance.now();
         this.startTime = this.previousTime;
         this.totalTime = 0;

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -89,6 +89,7 @@ export class GameHandler{
     calculateDeltaTime(){
         let currentTime = performance.now();
         this.deltaTime =(currentTime - this.previousTime) / 1000 * this.timescale;
+        this.previousTime = currentTime;
         this.totalTime += this.deltaTime;
     }
     drawHitboxes(){

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -18,6 +18,17 @@ export class GameHandler{
             }
         }
 
+        this.hellText = undefined;
+        this.hell = false;
+        if (urlParams.has("hell")) {
+            const paramHell = !!+urlParams.get("hell");
+            if (paramHell) {
+                this.hell = true;
+                this.hellText = new Text(ctx, this, "HELL{0}", "");
+                this.#texts.push(this.hellText);
+            }
+        }
+
         let icaHP = undefined;
         this.maxHPText = undefined;
         if (urlParams.has("icahp")) {
@@ -67,7 +78,7 @@ export class GameHandler{
         
         this.projectiles = [];
         this.waveHandler = new WaveHandler(this);
-        this.waveHandler.firstWave();
+        this.waveHandler.fourthWaveEnraged();
         this.previousTime = performance.now();
         this.startTime = this.previousTime;
         this.totalTime = 0;

--- a/GameHandler.js
+++ b/GameHandler.js
@@ -89,8 +89,7 @@ export class GameHandler{
     calculateDeltaTime(){
         let currentTime = performance.now();
         this.deltaTime =(currentTime - this.previousTime) / 1000 * this.timescale;
-        this.previousTime = currentTime;
-        this.totalTime = (currentTime-this.startTime)/1000;
+        this.totalTime += this.deltaTime;
     }
     drawHitboxes(){
         this.Ica.drawHitbox();

--- a/Ica.js
+++ b/Ica.js
@@ -3,18 +3,19 @@ import {InputHandler} from './inputHandler.js';
 import {HealthBar} from './healthbar.js';
 import {Kanal} from './kanal.js';
 export class Ica extends Character{
-    constructor(ctx, x, y, width, height, gameHandler){
+    static defaultHP = 100;
+
+    constructor(ctx, x, y, width, height, gameHandler, health = Ica.defaultHP){
         const spriteSrc = './assets/Ica_sprite.png';
         const speed = 800;
         const spriteAnimationFrames = {
             run: {sXMax:8, sY:8, stagger:3},
             hit: {sXMax:6, sY:12, stagger:3}
 
-
         };
         super(ctx, x, y, width, height, spriteSrc, spriteAnimationFrames, speed);
         this.range = 50;
-        this.healthbar = new HealthBar(this.ctx, 100, 100, this.hitbox.x- 50 + this.hitbox.width/2, this.hitbox.y+this.hitbox.height+10);
+        this.healthbar = new HealthBar(this.ctx, health, health, this.hitbox.x- 50 + this.hitbox.width/2, this.hitbox.y+this.hitbox.height+10);
         this.gameHandler = gameHandler;
         this.CurrentState = {...this.spriteAnimationFrames.run , speedX: 0, speedY: 0, sY : 0 ,running: false, hitting: false};
         this.Kanal = new Kanal(this.ctx,  60, 60, 0, 0, this, gameHandler);
@@ -28,16 +29,6 @@ export class Ica extends Character{
         
         super.draw();
         this.Kanal.draw();
-    } 
-
-    gotHit(damage = 10){
-        this.healthbar.health -= damage;
-        
-        // if(this.healthbar.health <= 0){
-        //     this.gameHandler.gameOver();
-        // }
-
-       
     }
 
     update(){
@@ -58,7 +49,7 @@ export class Ica extends Character{
         this.x += this.CurrentState.speedX;
         this.y += this.CurrentState.speedY;
         const hitbox = this.hitbox;
-        this.healthbar.x = hitbox.x- this.healthbar.maxHealth/2+ hitbox.width/2;
+        this.healthbar.x = this.hitbox.x- 50 + this.hitbox.width/2;
         this.healthbar.y = hitbox.y + hitbox.height + 5;
         this.Kanal.basePositionX = hitbox.x- 50 + hitbox.width/2;
         this.Kanal.basePositionY = hitbox.y- 50 + hitbox.height/2;

--- a/boss.js
+++ b/boss.js
@@ -8,7 +8,8 @@ export class Boss extends Projectile{
             super(gameHandler, "./assets/nemTudomKiEz.png", x, y, width, height, direction, rotation);
             rotation = 0;
             this.speed = 400;
-            this.damageFrequency = 50;
+            this.damageFrequency = 100;
+            this.percentDamage = 0.0075;
             this.healthbar = new HealthBar(this.gameHandler.ctx, 200, 200, this.centerX - 50, this.centerY+this.height/2+10);
             this.isCollided = false;
             this.carryCollisionTime = 0;
@@ -17,8 +18,8 @@ export class Boss extends Projectile{
             this.update();
             super.draw();
             if(this.gameHandler.etelhordok.length > 1) return;
-            this.healthbar.x = this.hitbox.x- this.healthbar.maxHealth/2+ this.hitbox.width/2;
-            this.healthbar.y = this.hitbox.y + this.hitbox.height + 5;
+            this.healthbar.x = this.centerX - 50;
+            this.healthbar.y = this.centerY+this.height/2+10;
             this.healthbar.draw();
             this.healthbar.update();
             if(this.healthbar.health <= 0){
@@ -26,6 +27,12 @@ export class Boss extends Projectile{
             }
             
         }
+
+        dealPercentDamage(){
+            let hp = this.gameHandler.Ica.healthbar;
+            hp.health -= hp.maxHealth * this.percentDamage;
+        }
+
         update(){
             this.centerX += this.Direction.x*this.gameHandler.deltaTime;
             this.centerY += this.Direction.y*this.gameHandler.deltaTime;
@@ -36,11 +43,13 @@ export class Boss extends Projectile{
                     let loopCount = this.gameHandler.deltaTime*this.damageFrequency+this.carryCollisionTime;
                     for (let i = 0; i < this.gameHandler.deltaTime*this.damageFrequency; i++) {
                         this.gameHandler.Ica.gotHit();
+                        this.dealPercentDamage();
                     }
                     this.carryCollisionTime = loopCount%1;
                 }
                 else{
                     this.gameHandler.Ica.gotHit();
+                    this.dealPercentDamage();
                 }
                 this.isCollided = true;
                 // this.gameHandler.projectiles.splice(this.gameHandler.projectiles.indexOf(this), 1);

--- a/boss.js
+++ b/boss.js
@@ -1,6 +1,7 @@
 import { Projectile } from "./projectile.js";
 import { HealthBar } from "./healthbar.js";
 import { Kanal } from "./kanal.js";
+import { Ica } from "./Ica.js";
 
 export class Boss extends Projectile{
     constructor(gameHandler,  x, y, width, height, direction, rotation)
@@ -9,7 +10,7 @@ export class Boss extends Projectile{
             rotation = 0;
             this.speed = 400;
             this.damageFrequency = 100;
-            this.percentDamage = 0.0075;
+            this.damageScaling = 0.95;
             this.healthbar = new HealthBar(this.gameHandler.ctx, 200, 200, this.centerX - 50, this.centerY+this.height/2+10);
             this.isCollided = false;
             this.carryCollisionTime = 0;
@@ -29,8 +30,11 @@ export class Boss extends Projectile{
         }
 
         dealPercentDamage(){
-            let hp = this.gameHandler.Ica.healthbar;
-            hp.health -= hp.maxHealth * this.percentDamage;
+            const hp = this.gameHandler.Ica.healthbar;
+            const hpDiff = (hp.maxHealth - Ica.defaultHP);
+            let extraDamage = Math.pow(hpDiff / 10, this.damageScaling);
+
+            hp.health -= extraDamage;
         }
 
         update(){

--- a/boss.js
+++ b/boss.js
@@ -1,5 +1,6 @@
 import { Projectile } from "./projectile.js";
 import { HealthBar } from "./healthbar.js";
+import { Kanal } from "./kanal.js";
 
 export class Boss extends Projectile{
     constructor(gameHandler,  x, y, width, height, direction, rotation)
@@ -7,8 +8,10 @@ export class Boss extends Projectile{
             super(gameHandler, "./assets/nemTudomKiEz.png", x, y, width, height, direction, rotation);
             rotation = 0;
             this.speed = 400;
-            this.healthbar = new HealthBar(this.gameHandler.ctx, 100, 100, this.centerX - 50, this.centerY+this.height/2+10);
-               
+            this.damageFrequency = 50;
+            this.healthbar = new HealthBar(this.gameHandler.ctx, 200, 200, this.centerX - 50, this.centerY+this.height/2+10);
+            this.isCollided = false;
+            this.carryCollisionTime = 0;
         }
         draw(){
             this.update();
@@ -29,8 +32,22 @@ export class Boss extends Projectile{
             this.angle += this.rotation*this.gameHandler.deltaTime;
            
             if(this.checkCollision(this.gameHandler.Ica)){
-                this.gameHandler.Ica.gotHit();
+                if (this.isCollided) {
+                    let loopCount = this.gameHandler.deltaTime*this.damageFrequency+this.carryCollisionTime;
+                    for (let i = 0; i < this.gameHandler.deltaTime*this.damageFrequency; i++) {
+                        this.gameHandler.Ica.gotHit();
+                    }
+                    this.carryCollisionTime = loopCount%1;
+                }
+                else{
+                    this.gameHandler.Ica.gotHit();
+                }
+                this.isCollided = true;
                 // this.gameHandler.projectiles.splice(this.gameHandler.projectiles.indexOf(this), 1);
+            }
+            else{
+                this.isCollided = false;
+                this.carryCollisionTime = 0;
             }
 
 
@@ -65,9 +82,8 @@ export class Boss extends Projectile{
        
         getHit(){
             if(this.gameHandler.etelhordok.length > 1) return;
-            let damage = 5;
             if (!this.destroyed) {
-                this.healthbar.health-=damage;
+                this.healthbar.health-=Kanal.damage;
                 this.healthbar.update();
                 
             }

--- a/etelhordo.js
+++ b/etelhordo.js
@@ -1,4 +1,5 @@
 import { HealthBar } from "./healthbar.js";
+import { Kanal } from "./kanal.js";
 export class Etelhordo{
     constructor(Gamehandler,x,y,health,sizeX=100,sizeY=100,healthBar){
         this.ctx = Gamehandler.ctx;
@@ -59,9 +60,8 @@ export class Etelhordo{
     }
     getHit(){
         this.clang.play();
-        let damage = 10;
         if (!this.destroyed) {
-            this.healthbar.health-=damage;
+            this.healthbar.health-=Kanal.damage;
             this.healthbar.update();
             
         }

--- a/etelhordo.js
+++ b/etelhordo.js
@@ -25,23 +25,39 @@ export class Etelhordo{
         this.sX = 0;
         this.sY=0;        
         this.destroyed = false;
+        this.deathTime = 0;
+        this.triggeredDeathAnimation = false;
+        this.deathTimeFrequency = 0.02;
     }
     
     draw(){
         this.ctx.drawImage(this.img, this.x, this.y, this.sizeX,this.sizeY);
         this.healthbar.draw();
         this.healthbar.update();
-        if (this.healthbar.health<=0) { 
-            if (this.sX!=9 &&this.sY!=7) {          
-                this.gameHandler.ctx.drawImage(this.spriteImage, this.sX * this.spriteWidth, this.sY  * this.spriteHeight, this.spriteWidth, this.spriteHeight, this.x, this.y, this.sizeX, this.sizeY);         
-                this.sX++;
-                if (this.sX==9) {
-                    this.sX=0;
-                    this.sY++;
-                }
-                this.destroyed=true;
-            }      
-            
+        if (this.healthbar.health<=0) {
+            //currentFrame => x, y
+            //
+            //0 => 0, 0
+            //1 => 1, 0
+            //...
+            //8 => 8, 0
+            //9 => 0, 1 => same result as original code
+            const currentFrame = Math.floor(this.deathTime / this.deathTimeFrequency);
+            const currentX = currentFrame % 9;
+            const currentY = Math.floor(currentFrame / 9);
+            // this check ensures that the deltaTime of the frame BEFORE the actual death of this object isn't counted.
+            if (this.triggeredDeathAnimation) {
+                this.deathTime += this.gameHandler.deltaTime;
+            }
+            else{
+                this.triggeredDeathAnimation = true;
+            }
+            //- 
+            //- changed from != to <, to ensure that freezes don't break the code and make the animation permanent
+            if (currentY<7) {
+
+                this.drawAnimation(currentX, currentY)
+            }
             else{
                 this.gameHandler.etelhordok.splice(this.gameHandler.etelhordok.indexOf(this), 1);
                 
@@ -56,8 +72,6 @@ export class Etelhordo{
             this.healthbar.update();
             
         }
-
-
     }
     drawHitbox(){
         this.ctx.beginPath();
@@ -65,10 +79,8 @@ export class Etelhordo{
         this.ctx.strokeStyle = "red";
         this.ctx.stroke();
     }
-    drawAnimation(){
-
-        this.gameHandler.ctx.drawImage(this.spriteImage, this.sX * this.spriteWidth, this.sY  * this.spriteHeight, this.spriteWidth, this.spriteHeight, this.x, this.y, this.sizeX, this.sizeY);
-
+    drawAnimation(currentX, currentY){
+        this.gameHandler.ctx.drawImage(this.spriteImage, currentX * this.spriteWidth, currentY  * this.spriteHeight, this.spriteWidth, this.spriteHeight, this.x, this.y, this.sizeX, this.sizeY);
     }
 
 

--- a/etelhordo.js
+++ b/etelhordo.js
@@ -21,9 +21,7 @@ export class Etelhordo{
         this.hitboxEndY=this.y+sizeY/1.15; 
         this.gameHandler = Gamehandler;
         this.spriteWidth =100;
-        this.spriteHeight = 20;
-        this.sX = 0;
-        this.sY=0;        
+        this.spriteHeight = 20; 
         this.destroyed = false;
         this.deathTime = 0;
         this.triggeredDeathAnimation = false;

--- a/etelhordo.js
+++ b/etelhordo.js
@@ -43,18 +43,13 @@ export class Etelhordo{
             const currentFrame = Math.floor(this.deathTime / this.deathTimeFrequency);
             const currentX = currentFrame % 9;
             const currentY = Math.floor(currentFrame / 9);
-            // this check ensures that the deltaTime of the frame BEFORE the actual death of this object isn't counted.
-            if (this.triggeredDeathAnimation) {
-                this.deathTime += this.gameHandler.deltaTime;
-            }
-            else{
-                this.triggeredDeathAnimation = true;
-            }
-            //- 
-            //- changed from != to <, to ensure that freezes don't break the code and make the animation permanent
             if (currentY<7) {
-
+                // this check ensures that the deltaTime of the frame BEFORE the actual death of this object isn't counted.
+                if (this.destroyed) {
+                    this.deathTime += this.gameHandler.deltaTime;
+                }
                 this.drawAnimation(currentX, currentY)
+                this.destroyed = true;
             }
             else{
                 this.gameHandler.etelhordok.splice(this.gameHandler.etelhordok.indexOf(this), 1);

--- a/gameover.js
+++ b/gameover.js
@@ -9,7 +9,7 @@ window.addEventListener('resize', () => {
 const restart = document.getElementById('restart').addEventListener('click', restartGame);
 
 function restartGame() {
-    window.open("./game.html", "_self");
+    window.open("./game.html" + window.location.search, "_self");
 }
 
 function dyingICA() {    

--- a/healthbar.js
+++ b/healthbar.js
@@ -16,8 +16,10 @@ export class HealthBar{
     }
     update(){
         this.ctx.beginPath();
-        this.ctx.rect(this.x+this.health,this.y,this.maxHealth-this.health,9.8);
+        const currentHPRatio = (this.health/this.maxHealth)*100;
+        const lostHPRatio = 100-currentHPRatio;
+        this.ctx.rect(this.x+currentHPRatio,this.y,lostHPRatio,10);
         this.ctx.fillStyle ="red";
-        this.ctx.fill()
+        this.ctx.fill();
     }
 }

--- a/kanal.js
+++ b/kanal.js
@@ -1,4 +1,5 @@
 export class Kanal {
+    static damage = 10;
     constructor(ctx, width, height, x, y, ica, gameHandler) {
         
         this.context = ctx;

--- a/startpage.js
+++ b/startpage.js
@@ -84,5 +84,5 @@ function dancingICA() {
 }
 
 function startGame() {
-    window.open("./game.html", "_self");
+    window.open("./game.html" + window.location.search, "_self");
 }

--- a/text.js
+++ b/text.js
@@ -1,0 +1,240 @@
+export class Text{
+    static defaultSize = 30;
+    static defaultMeasure = "px";
+    static defaultFont = "monospace"
+    size = Text.defaultSize;
+    measure = Text.defaultMeasure;
+    font = Text.defaultFont;
+    #formatString = "";
+    #value = "";
+    #fullText = "";
+
+    get fullFont(){
+        return `${this.size}${this.measure} ${this.font}`;
+    }
+
+    static get fullDefaultFont(){
+        return `${Text.defaultSize}${Text.defaultMeasure} ${Text.defaultFont}`
+    }
+    
+    get formatString(){
+        return this.#formatString;
+    }
+    set formatString(value){
+        if (value == this.#formatString) {
+            return;
+        }
+        const isFormattable = Text.IsFormattableWithCount(value, 1);
+        if (isFormattable == null) {
+            throw new Error("The value was not a valid formattable string");
+        }
+        if (isFormattable == false) {
+            throw new Error("The value was not formattable with 1 element");
+        }
+        this.#formatString = value;
+        this.#updateFullText();
+    }
+
+    get value(){
+        return this.#value;
+    }
+    set value(value){
+        if (this.#value == value) {
+            return;
+        }
+        this.#value = value;
+        this.#updateFullText();
+    }
+
+    get fullText(){
+        return this.#fullText;
+    }
+    #updateFullText(){
+        this.#fullText = Text.Format(this.#formatString, this.#value);
+    }
+
+    draw(x,y){
+        this.ctx.font = this.fullFont;
+        this.ctx.fillText(this.#fullText, x, y)
+    }
+
+    constructor(ctx, gameHandler, formatString, value){
+        this.ctx = ctx;
+        this.gameHandler = gameHandler;
+        this.formatString = formatString;
+        this.value = value;
+    }
+
+    /// If invalid: returns null
+    /// Returns whether the string is formattable with the given number of arguments
+    static IsFormattableWithCount(string, count){
+        if (typeof(string) !== typeof("")) {
+            throw new Error(`Parameter '${Object.keys({string})[0]}' was not a string!`)
+        }
+        if (typeof(count) !== typeof(0) || !Number.isSafeInteger(count)) {
+            throw new Error(`Parameter '${Object.keys({count})[0]}' was not a safe integer!`)
+        }
+        let usedArgs = {};
+        
+        let readingArgIndex = "";
+        let readingArgIndexState = -1; // -1: not parsing, 0: got '{', 1: got a different character than '{'
+        // special case: 2: got a '}' while not parsing (wait for next character)
+        for (let i = 0; i < string.length; i++) {
+            const char = string[i];
+            switch (char) {
+                case "{":
+                    switch (readingArgIndexState) {
+                        case -1:
+                            readingArgIndexState++;
+                            break;
+                        case 0:
+                            readingArgIndexState = -1;
+                            break;
+                        case 1:
+                        case 2:
+                            return false;
+                        default:
+                            return false;
+                    }
+                    break;
+                case "}":
+                    switch (readingArgIndexState) {
+                        case -1:
+                            readingArgIndexState++;
+                            break;
+                        case 0:
+                            return false;
+                        case 1:
+                            if (!readingArgIndex.replace(/\s/g, '').length) {
+                                return false;
+                            }
+                            const idx = +readingArgIndex;
+                            if (!Number.isSafeInteger(idx) || idx < 0) {
+                                return false;
+                            }
+                            if (idx >= count) {
+                                return false;
+                            }
+                            usedArgs[idx]=0;
+                            readingArgIndexState = -1;
+                            break;
+                        case 2:
+                            readingArgIndexState = -1;
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
+                default:
+                    switch (readingArgIndexState) {
+                        case -1:
+                            break;
+                        case 0:
+                            readingArgIndexState++;
+                            readingArgIndex += char;
+                            break;
+                        case 1:
+                            readingArgIndex += char;
+                            break;
+                        case 2:
+                            return false;
+                        default:
+                            return false;
+                    }
+                    break;
+            }
+        }
+        if (Object.keys(usedArgs).length != count) {
+            return false;
+        }
+        return true;
+    }
+
+    static Format(string){
+        let args = [];
+        for (var i = 0; i < arguments.length; ++i) args[i] = arguments[i];
+        args = args.splice(1, args.length-1);
+        let usedArgs = {};
+        if (typeof(string) !== typeof("")) {
+            throw new Error(`Parameter '${Object.keys({string})[0]}' was not a string!`);
+        }
+        
+        let readingArgIndex = "";
+        let readingArgIndexState = -1; // -1: not parsing, 0: got '{', 1: got a different character than '{'
+        // special case: 2: got a '}' while not parsing (wait for next character)
+        let result = "";
+        for (let i = 0; i < string.length; i++) {
+            const char = string[i];
+            switch (char) {
+                case "{":
+                    switch (readingArgIndexState) {
+                        case -1:
+                            readingArgIndexState++;
+                            break;
+                        case 0:
+                            readingArgIndexState = -1;
+                            result += char;
+                            break;
+                        case 1:
+                        case 2:
+                            throw new Error(`Unexpected opening braces at position ${i}`);
+                        default:
+                            throw new Error("Unhandled index state (complain to developer)");
+                    }
+                    break;
+                case "}":
+                    switch (readingArgIndexState) {
+                        case -1:
+                            readingArgIndexState++;
+                            break;
+                        case 0:
+                            throw new Error(`Unexpected closing braces at position ${i}`);
+                        case 1:
+                            if (!readingArgIndex.replace(/\s/g, '').length) {
+                                throw new Error(`Missing argument index (whitespace only) at position ${i}`);
+                            }
+                            const idx = +readingArgIndex;
+                            if (!Number.isSafeInteger(idx) || idx < 0) {
+                                throw new Error(`Invalid argument index at position ${i}`);
+                            }
+                            if (idx >= args.length) {
+                                throw new Error(`Argument index out of range at position ${i}`);
+                            }
+                            result += String(args[idx]);
+                            usedArgs[idx]=0;
+                            readingArgIndexState = -1;
+                            break;
+                        case 2:
+                            readingArgIndexState = -1;
+                            result += char;
+                            break;
+                        default:
+                            throw new Error("Unhandled index state (complain to developer)");
+                    }
+                    break;
+                default:
+                    switch (readingArgIndexState) {
+                        case -1:
+                            result += char;
+                            break;
+                        case 0:
+                            readingArgIndexState++;
+                            readingArgIndex += char;
+                            break;
+                        case 1:
+                            readingArgIndex += char;
+                            break;
+                        case 2:
+                            throw new Error(`Unexpected closing braces at position ${i-1}`);
+                        default:
+                            throw new Error("Unhandled index state (complain to developer)");
+                    }
+                    break;
+            }
+        }
+        if (Object.keys(usedArgs).length != args.length) {
+            throw new Error("Unused formatting arguments");
+        }
+        return result;
+    }
+}

--- a/text.js
+++ b/text.js
@@ -64,7 +64,9 @@ export class Text{
         this.formatString = formatString;
         this.value = value;
     }
-
+    static IsNullOrWhitespace(string){
+        return !string || !string.replace(/\s/g, '').length
+    }
     /// If invalid: returns null
     /// Returns whether the string is formattable with the given number of arguments
     static IsFormattableWithCount(string, count){
@@ -105,7 +107,7 @@ export class Text{
                         case 0:
                             return false;
                         case 1:
-                            if (!readingArgIndex.replace(/\s/g, '').length) {
+                            if (Text.IsNullOrWhitespace(readingArgIndex)) {
                                 return false;
                             }
                             const idx = +readingArgIndex;
@@ -190,7 +192,7 @@ export class Text{
                         case 0:
                             throw new Error(`Unexpected closing braces at position ${i}`);
                         case 1:
-                            if (!readingArgIndex.replace(/\s/g, '').length) {
+                            if (Text.IsNullOrWhitespace(readingArgIndex)) {
                                 throw new Error(`Missing argument index (whitespace only) at position ${i}`);
                             }
                             const idx = +readingArgIndex;

--- a/text.js
+++ b/text.js
@@ -21,14 +21,14 @@ export class Text{
         return this.#formatString;
     }
     set formatString(value){
-        if (value == this.#formatString) {
+        if (value === this.#formatString) {
             return;
         }
         const isFormattable = Text.IsFormattableWithCount(value, 1);
-        if (isFormattable == null) {
+        if (isFormattable === null) {
             throw new Error("The value was not a valid formattable string");
         }
-        if (isFormattable == false) {
+        if (isFormattable === false) {
             throw new Error("The value was not formattable with 1 element");
         }
         this.#formatString = value;
@@ -39,7 +39,7 @@ export class Text{
         return this.#value;
     }
     set value(value){
-        if (this.#value == value) {
+        if (this.#value === value) {
             return;
         }
         this.#value = value;

--- a/text.js
+++ b/text.js
@@ -1,5 +1,5 @@
 export class Text{
-    static defaultSize = 30;
+    static defaultSize = 25;
     static defaultMeasure = "px";
     static defaultFont = "monospace"
     size = Text.defaultSize;

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,21 @@
+export class Utils{
+    static getWidth() {
+        return Math.max(
+          document.body.scrollWidth,
+          document.documentElement.scrollWidth,
+          document.body.offsetWidth,
+          document.documentElement.offsetWidth,
+          document.documentElement.clientWidth
+        );
+      }
+      
+    static getHeight() {
+        return Math.max(
+          document.body.scrollHeight,
+          document.documentElement.scrollHeight,
+          document.body.offsetHeight,
+          document.documentElement.offsetHeight,
+          document.documentElement.clientHeight
+        );
+      }
+}

--- a/waveHandler.js
+++ b/waveHandler.js
@@ -93,7 +93,7 @@ export class WaveHandler {
             
             console.log(speed);
             let projectileGapStart;
-                projectileGapStart = Math.floor(Math.random() * (this.gameHandler.width/projectileSize-0.5));
+                projectileGapStart = Math.floor(Math.random() * (this.gameHandler.width/projectileSize-1));
                 //checks if gap is too far from ica
             
             
@@ -110,7 +110,7 @@ export class WaveHandler {
         else if(y === -1){
             let ratio = Utils.getWidth()/(Utils.getHeight()*2);
             let speed = ratio*562.5;
-            let projectileGapStart = Math.floor(Math.random() * (this.gameHandler.height/projectileSize-0.5));
+            let projectileGapStart = Math.floor(Math.random() * (this.gameHandler.height/projectileSize-1));
             for (let i = 0; i < this.gameHandler.height/projectileSize; i++) {
                 if(i < projectileGapStart || i > projectileGapStart+gapSize){
                     let y = i*projectileSize;
@@ -337,7 +337,7 @@ export class WaveHandler {
     fourthWaveEnraged(){
         this.fourthWave();
         this.gameHandler.etelhordok.splice(0, this.gameHandler.etelhordok.length-1);
-        
+
     }
     
 }

--- a/waveHandler.js
+++ b/waveHandler.js
@@ -90,8 +90,6 @@ export class WaveHandler {
         if(x === -1){
             let ratio = Utils.getHeight()/(Utils.getWidth()*1.66); 
             let speed = ratio*700;
-            
-            console.log(speed);
             let projectileGapStart;
                 projectileGapStart = Math.floor(Math.random() * (this.gameHandler.width/projectileSize-1));
                 //checks if gap is too far from ica
@@ -279,7 +277,6 @@ export class WaveHandler {
         let proj0count = 0;
         let proj1count = 0;
         for (const element of this.gameHandler.projectiles) {
-            console.log(element.imageSource == this.projectileTypes[0].src)
             if (element.imageSource == this.projectileTypes[0].src) {
                 proj0count++;
             }

--- a/waveHandler.js
+++ b/waveHandler.js
@@ -1,6 +1,7 @@
 import {Etelhordo} from "./etelhordo.js";
 import { Projectile } from "./projectile.js";
 import {Boss} from "./boss.js";
+import { Utils } from './utils.js';
 
 
 export class WaveHandler {
@@ -45,7 +46,7 @@ export class WaveHandler {
     get isWaveCleared(){
         return this.gameHandler.etelhordok.length == 0;
     }
-    createProjectile(x,y,direction,proj){
+    createProjectile(x,y,direction,proj,speed=500){
         // Calculate the length of the direction vector
         let length = Math.sqrt(direction.x * direction.x + direction.y * direction.y);
         
@@ -54,7 +55,6 @@ export class WaveHandler {
             x: direction.x / length,
             y: direction.y / length
         };
-        let speed = 500; // Change this to the desired speed
         
         // Multiply the normalized direction vector by the speed
         let finalDirection = {
@@ -82,11 +82,18 @@ export class WaveHandler {
             
         }
     }
+    // multiplying ratios, because:
+    // - if the holes are on opposing sides, you need enough time to reach one side, then loop around to the other
+    // - you need to reach the holes before the walls reach the halfway point
     createProjectileWall(x,y,gapSize,projectile){
         let projectileSize = projectile.size || 50;
         if(x === -1){
+            let ratio = Utils.getHeight()/(Utils.getWidth()*1.66); 
+            let speed = ratio*700;
+            
+            console.log(speed);
             let projectileGapStart;
-                projectileGapStart = Math.floor(Math.random() * (this.gameHandler.width/projectileSize));
+                projectileGapStart = Math.floor(Math.random() * (this.gameHandler.width/projectileSize-0.5));
                 //checks if gap is too far from ica
             
             
@@ -94,21 +101,22 @@ export class WaveHandler {
                 if(i < projectileGapStart || i > projectileGapStart+gapSize){
                     let x = i*projectileSize;
                     let yy = y*this.gameHandler.height;
-                    this.createProjectile(x,yy,{x: 0, y: 1-y*2}, projectile);
+                    this.createProjectile(x,yy,{x: 0, y: 1-y*2}, projectile, speed);
                 }
                 
             }
 
         }
         else if(y === -1){
-            let projectileGapStart = Math.floor(Math.random() * (this.gameHandler.height/projectileSize));
+            let ratio = Utils.getWidth()/(Utils.getHeight()*2);
+            let speed = ratio*562.5;
+            let projectileGapStart = Math.floor(Math.random() * (this.gameHandler.height/projectileSize-0.5));
             for (let i = 0; i < this.gameHandler.height/projectileSize; i++) {
                 if(i < projectileGapStart || i > projectileGapStart+gapSize){
                     let y = i*projectileSize;
                     let xx = x*this.gameHandler.width;
-                    this.createProjectile(xx,y,{x: 1-x*2, y: 0}, projectile);
+                    this.createProjectile(xx,y,{x: 1-x*2, y: 0}, projectile, speed);
                 }
-                
             }
         }
     }
@@ -191,39 +199,74 @@ export class WaveHandler {
         this.projectileFrequency = 1000;
         this.gameHandler.etelhordok = [];   
         this.gameHandler.projectiles = [];
-        this.createEtelhordo(5);
-       
-        this.updateCurrentWave = this.updateFirstWave;
+
+        if (this.gameHandler.hell) {
+            this.createEtelhordo(10);
+            this.updateCurrentWave = this.updateBuffedFirstWave;
+        }
+        else{
+            this.createEtelhordo(5);
+            this.updateCurrentWave = this.updateFirstWave;
+        }
         this.nextWave = this.secondWave;
     }
     
     updateFirstWave(){
         
         this.createProjectiles(5);
-       
+    }
+    updateBuffedFirstWave(){
         
-        
+        this.createProjectiles(10);
     }
     
     secondWave(){
         this.gameHandler.etelhordok = [];   
-        this.createEtelhordo(8);
-        this.updateCurrentWave = this.updateSecondWave;
+        if (this.gameHandler.hell) {
+            this.createEtelhordo(16);
+            this.updateCurrentWave = this.updateBuffedSecondWave;
+        }
+        else{
+            this.createEtelhordo(8);
+            this.updateCurrentWave = this.updateSecondWave;
+        }
         this.nextWave = this.thirdWave;
         this.createProjectileWall(1,-1,5,this.projectileTypes[0]);
     }
     updateSecondWave(){
         if(this.gameHandler.projectiles.length == 0){
-
             this.createProjectileWall(1,-1,6,this.projectileTypes[0]);
             this.createProjectileWall(0,-1,6,this.projectileTypes[0]);
         }
         
     }
+    updateBuffedSecondWave(){
+        if(this.gameHandler.projectiles.length == 0){
+            if (Math.random() < 0.5) {
+                this.createProjectileWall(1,-1,6,this.projectileTypes[0]);
+            }
+            else{
+                this.createProjectileWall(-1,1,6,this.projectileTypes[0]);
+            }
+            if (Math.random() < 0.5) {
+                this.createProjectileWall(0,-1,6,this.projectileTypes[0]);
+            }
+            else{
+                this.createProjectileWall(-1,0,6,this.projectileTypes[0]);
+            }
+        }
+        
+    }
     thirdWave(){
         this.gameHandler.etelhordok = [];   
-        this.createEtelhordo(3);
-        this.updateCurrentWave = this.updateThirdWave;
+        if (this.gameHandler.hell) {
+            this.createEtelhordo(10);
+            this.updateCurrentWave = this.updateBuffedThirdWave;
+        }
+        else{
+            this.createEtelhordo(3);
+            this.updateCurrentWave = this.updateThirdWave;
+        }
         this.nextWave = this.fourthWave;
     }
     updateThirdWave(){
@@ -232,17 +275,50 @@ export class WaveHandler {
         }
         
     }
+    updateBuffedThirdWave(){
+        let proj0count = 0;
+        let proj1count = 0;
+        for (const element of this.gameHandler.projectiles) {
+            console.log(element.imageSource == this.projectileTypes[0].src)
+            if (element.imageSource == this.projectileTypes[0].src) {
+                proj0count++;
+            }
+            else{
+                proj1count++;
+            }
+        }
+        while (proj1count < 5) {
+            const originalProjectileType = this.projectileTypes;
+            this.projectileTypes = this.projectileTypes.slice(1);
+            this.createProjectiles(100);
+            this.projectileTypes = originalProjectileType;
+            proj1count++;
+        }
+        if(proj0count == 0){
+            this.createProjectileRing(40,this.projectileTypes[0]);
+        }
+        
+    }
     fourthWave(){
         this.gameHandler.etelhordok = [];   
-         this.createEtelhordo(7);
-        this.updateCurrentWave = this.updateThirdWave;
+        if (this.gameHandler.hell) {
+            this.createEtelhordo(15);
+            this.updateCurrentWave = this.updateBuffedFourthWave;
+        }
+        else{
+            this.createEtelhordo(7);
+            this.updateCurrentWave = this.updateFourthWave;
+        }
         this.nextWave = null;
         this.gameHandler.projectiles = [];
         let bossX = this.gameHandler.Ica.x>this.gameHandler.width/2? 0: this.gameHandler.width;
         let bossY = this.gameHandler.Ica.y>this.gameHandler.height? 0: this.gameHandler.height;
         let Vazso = new Boss(this.gameHandler,bossX,bossY,100,100, {x: 0, y: 0},0);
         this.gameHandler.etelhordok.push(Vazso);
-        this.updateCurrentWave = this.updateFourthWave;
+        if (this.gameHandler.hell) {
+            Vazso.healthbar.maxHealth *= 5;
+            Vazso.healthbar.health *= 5;
+        }
 
     }
     updateFourthWave(){
@@ -250,7 +326,17 @@ export class WaveHandler {
             return;
         }
         this.createProjectiles(10);
-        
+    }
+    updateBuffedFourthWave(){
+        if(this.gameHandler.etelhordok.length >1){
+            return;
+        }
+        this.createProjectiles(20);
+    }
+
+    fourthWaveEnraged(){
+        this.fourthWave();
+        this.gameHandler.etelhordok.splice(0, this.gameHandler.etelhordok.length-1);
         
     }
     

--- a/win.js
+++ b/win.js
@@ -1,5 +1,5 @@
 const restart = document.getElementById('restart').addEventListener('click', restartGame);
 
 function restartGame() {
-    window.open("./game.html", "_self");
+    window.open("./game.html" + window.location.search, "_self");
 }


### PR DESCRIPTION
This is a feature summary, check commits for implementation details:

The barrel death animation was framerate dependent.\
This made the animation faster on high-end devices, proceeding to the next phase faster and making the game not only easier, but also makes speedruns faster.\
The animation is now dependent on delta time.

Healthbar scaling wasn't properly implemented, leading to visual glitches when the maximum HP was anything other than 100.\
The healthbar was also drawn differently in it's update loop than in it's constructor. These have been rectified.

The damage of the boss was framerate dependent.\
This meant that when playing the game on a low-end machine, getting touched by the boss barely dealt damage, while on a high-end machine, it instantly killed you.\
It now uses the delta time, with a default hit frequency of 50 times per second.

Implemented the Text class to make drawing text on the screen easier.

Implemented time scaling.
Implemented damage scaling.
Implemented HP scaling.
Implemented timer.
Added a "Hell" gamemode.

Added url parameters for speedrun features:
- icahp: changes your max HP (integer)
- timer: displays the timer (true if non-zero)
- speed: sets the timescale (non-negative finite float)
    - slower for TAS purposes
    - faster for challenge runs
- damage: change damage dealt to objects
- wave: start at a specific wave
- hell: try it yourself :)
If a "cheat" parameter is set to anything other than the default, it will be displayed on the top left corner, below the timer.